### PR TITLE
Fix 404 page; add config-driven structured data

### DIFF
--- a/assets/css/extended/04-404.css
+++ b/assets/css/extended/04-404.css
@@ -1,0 +1,73 @@
+/* ============================================================================
+   brot-dev OVERRIDE — assets/css/extended/04-404.css
+   Place at:  brot-dev/assets/css/extended/04-404.css
+
+   Styles the redesigned site-level 404 (layouts/404.html). The theme's
+   common/404.css only styles a bare `.not-found` numeral (position:absolute,
+   font-size:160px) — so the redesigned markup (.nf-code / .nf-msg / .nf-home)
+   had no styles and the message + link inherited the 160px giant. This resets
+   .not-found to a calm centered column and styles the new parts on-brand.
+   Loaded last → wins.
+   ========================================================================== */
+
+/* Reset the theme's giant absolute numeral back to a calm centered column */
+.not-found {
+  position: static;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 62vh;
+  height: auto;
+  padding: 2rem 1rem;
+  font-size: inherit;
+  font-weight: inherit;
+  text-align: center;
+}
+
+.not-found-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  max-width: 32rem;
+}
+
+/* Big green numeral — wide, heavy Neue DIN VAR (Safari slnt guardrail) */
+.nf-code {
+  margin: 0;
+  font-family: var(--ui-font-family);
+  font-style: normal;
+  font-weight: var(--w-black);
+  font-stretch: 122%;
+  font-variation-settings: 'wght' 900, 'wdth' 122, 'slnt' 0;
+  font-size: clamp(6rem, 22vw, 13rem);
+  line-height: 0.9;
+  letter-spacing: -0.02em;
+  color: var(--accent);
+}
+
+.nf-msg {
+  margin: 0;
+  font-family: var(--ui-font-family);
+  font-style: normal;
+  font-weight: var(--w-medium);
+  font-variation-settings: 'wght' 500, 'slnt' 0;
+  font-size: clamp(1.05rem, 2.5vw, 1.35rem);
+  color: var(--primary);
+}
+
+/* A way home — green text on a hairline that thickens on hover (brand link style) */
+.nf-home {
+  margin-top: 0.8rem;
+  font-family: var(--ui-font-family);
+  font-style: normal;
+  font-weight: var(--w-semibold);
+  font-variation-settings: 'wght' 600, 'slnt' 0;
+  color: var(--accent);
+  box-shadow: 0 1px 0 var(--br-accent-line);
+  transition: box-shadow 0.18s ease, color 0.18s ease;
+}
+.nf-home:hover {
+  color: var(--br-accent-hover);
+  box-shadow: 0 2px 0 var(--accent);
+}

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -1,6 +1,8 @@
 ---
-title: 'About Me'
+title: 'About Alex Kellermann'
+description: 'Alex Kellermann — Security engineer in NYC writing about cameras, photography, and sometimes even security.'
 weight: 10
+type: about
 layout: about
 ---
 
@@ -19,14 +21,14 @@ Hey! I'm Alex Kellermann, a Security Engineer based in New York City, Cloud Secu
 | Cybersecurity Engineer [**@MITRE**](https://mitre.org)         | *2019—2021* |
 
 ## Site Details:
-- Static Website hosted on GitHub Pages
+- Static Website hosted on CloudFlare Pages
 - Cloudflare for Analytics
 
 ## Socials:
 
 I can be found on some other places too!
 
+- [Blue Sky](https://bsky.app/profile/brot.dev)
 - [Instagram](https://www.instagram.com/7traindelay/)
-- [LinkedIn](https://www.linkedin.com/in/alexkellermann/)
 - [GitHub](https://github.com/akellermann97)
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -23,6 +23,29 @@ hideAuthor = true
 [params.label]
   text = "🍞 brot.dev"
 
+# ----------------------------------------------------------------------------
+# Structured data (schema.org / JSON-LD) — drives partials/templates/schema_json.html
+#
+# Section → schema-type routing lives here (not in templates) so renaming a
+# content section or adding a new one only touches this block:
+#   • personSection : the section whose page represents the site's Person (you)
+#   • blogSections  : sections whose pages are Blogs / BlogPostings (append to grow)
+#   • publisherType : entity type for the site's author/publisher (Person | Organization)
+# ----------------------------------------------------------------------------
+[params.schema]
+  publisherType = "Person"
+  personSection = "about"
+  blogSections  = ["posts", "gallery"]
+
+  # Identity used to build the canonical Person entity.
+  jobTitle   = "Security Engineer"
+  knowsAbout = ["Cloud Security", "Application Security", "Photography"]
+  sameAs = [
+    "https://www.instagram.com/7traindelay/",
+    "https://www.linkedin.com/in/alexkellermann/",
+    "https://github.com/akellermann97",
+  ]
+
 
 [markup]
   [markup.goldmark]


### PR DESCRIPTION
- assets/css/extended/04-404.css: style the redesigned 404 markup (.nf-code/.nf-msg/.nf-home) and reset the theme's oversized absolute numeral, which was enlarging the message and link too.
- hugo.toml: add [params.schema] driving section -> JSON-LD routing (personSection, blogSections, publisherType) plus Person identity (jobTitle, knowsAbout, sameAs).
- content/about/index.md: set type: about so the page uses the dedicated about layout (description stays meta/SEO-only).
- Bump brot theme: structured data + about layout cleanup.