### PR TITLE
Upgrade Hugo from 0.126.3 to 0.163.1

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.126.3
+      HUGO_VERSION: 0.163.1
     steps:
       - name: Install Hugo CLI
         run: |

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,6 @@
 baseURL = 'https://brot.dev/'
 author = "Alex Kellermann"
-languageCode = 'en-us'
+locale = 'en-us'
 title = 'BROT.DEV 🍞'
 theme = 'brot'
 enableInlineShortcodes = true

--- a/hugo.toml
+++ b/hugo.toml
@@ -20,6 +20,7 @@ defaultTheme = "auto"
 images = ["brotheader.png"]
 hideAuthor = true
 
+
 [params.label]
   text = "🍞 brot.dev"
 


### PR DESCRIPTION
- Rename deprecated languageCode config key to locale (Hugo 0.158)
- Bump HUGO_VERSION in the Pages deploy workflow to 0.163.1
- Update brot theme submodule with 0.163.x compatibility fixes